### PR TITLE
Reorganized params; remove optional params(kappa, pme_order)

### DIFF
--- a/admp/api.py
+++ b/admp/api.py
@@ -306,7 +306,7 @@ class ADMPPmeGenerator:
         # here box is only used to setup ewald parameters, no need to be differentiable
         a, b, c = system.getDefaultPeriodicBoxVectors()
         box = jnp.array([a._value, b._value, c._value]) * 10
-        self.params['box'] = box
+
         # get the admp calculator
         rc = nonbondedCutoff.value_in_unit(unit.angstrom)
 

--- a/admp/pme.py
+++ b/admp/pme.py
@@ -39,7 +39,7 @@ class ADMPPmeForce:
         self.axis_indices = axis_indices
         self.rc = rc
         self.ethresh = ethresh
-        self.lmax = lmax
+        self.lmax = int(lmax)  # jichen: type checking
         kappa, K1, K2, K3 = setup_ewald_parameters(rc, ethresh, box)
         self.kappa = kappa
         self.K1 = K1

--- a/examples/openmm_api/forcefield.xml
+++ b/examples/openmm_api/forcefield.xml
@@ -20,7 +20,7 @@
    <Atom type="381" A="83.2283563" B="37.78544799"  Q="0.370853" C6="5.7929e-05" C8="1.416624e-06" C10="2.26525e-08"/>
  </ADMPDispForce>
 
- <ADMPPmeForce kappa="0.68" pme_order="6" lmax="2" mScale12="0.00" mScale13="0.00" mScale14="0.00" mScale15="1.00" mScale16="1.00">
+ <ADMPPmeForce kappa="0.65706" pme_order="6" lmax="2" mScale12="0.00" mScale13="0.00" mScale14="0.00" mScale15="1.00" mScale16="1.00">
    <Atom type="380" kz="-381" kx="-381"
              c0="-1.0614"
              dX="0.0" dY="0.0"  dZ="-0.023671684"

--- a/examples/openmm_api/forcefield.xml
+++ b/examples/openmm_api/forcefield.xml
@@ -20,7 +20,7 @@
    <Atom type="381" A="83.2283563" B="37.78544799"  Q="0.370853" C6="5.7929e-05" C8="1.416624e-06" C10="2.26525e-08"/>
  </ADMPDispForce>
 
- <ADMPPmeForce kappa="0.65706" pme_order="6" lmax="2" mScale12="0.00" mScale13="0.00" mScale14="0.00" mScale15="1.00" mScale16="1.00">
+ <ADMPPmeForce lmax="2" mScale12="0.00" mScale13="0.00" mScale14="0.00" mScale15="1.00" mScale16="1.00">
    <Atom type="380" kz="-381" kx="-381"
              c0="-1.0614"
              dX="0.0" dY="0.0"  dZ="-0.023671684"


### PR DESCRIPTION
1. remove kappa and pme_order in xml file, which should be calculated from rc and ethresh;
2. move 'c0/dx/dy etc.' from `params` to `_input_params`, which don't need to be differentiated;
3. store `Q_local` and `mScales` in params, which should be differentiated.

TODO: check whether kappa in admp and mpid are equal; 
add polarization support.